### PR TITLE
lockdown: Windows reconnect on remote close

### DIFF
--- a/pymobiledevice3/lockdown.py
+++ b/pymobiledevice3/lockdown.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import plistlib
+import sys
 import tempfile
 import time
 from abc import ABC, abstractmethod
@@ -56,15 +57,21 @@ def _reconnect_on_remote_close(f):
     transmitted). When this happens, we'll attempt to reconnect.
     """
 
+    def _reconnect(self: 'LockdownClient'):
+        self._reestablish_connection()
+        self.validate_pairing()
+
     @wraps(f)
     def _inner_reconnect_on_remote_close(*args, **kwargs):
         try:
             return f(*args, **kwargs)
         except (BrokenPipeError, ConnectionTerminatedError):
-            self: LockdownClient = args[0]
-
-            self._reestablish_connection()
-            self.validate_pairing()
+            _reconnect(args[0])
+            return f(*args, **kwargs)
+        except ConnectionAbortedError:
+            if sys.platform != "win32":
+                raise
+            _reconnect(args[0])
             return f(*args, **kwargs)
 
     return _inner_reconnect_on_remote_close


### PR DESCRIPTION
This commit introduced raising a `ConnectionAbortedError` when receiving an empy chunk, https://github.com/doronz88/pymobiledevice3/commit/83e2df4210f66b2cb8030c7350d77ee90b280bae 

On Windows only, after 1-5 minutes of radio silence, remote will send empty data response.  I couldn't nail down an exact period on Windows. Sometimes empty data is in the response, other times a `SSLEOFError` is raised.  The latter is default behaviour on Mac.

### Normal request
lockdown.date, within 1min
```
17:47:43 10 {'Label': 'pymobiledevice3', 'Request': 'GetValue', 'Key': 'TimeIntervalSince1970'}
17:47:43 10 plist_send=b'\x00\x00\x01W<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Key</key>\n\t<string>TimeIntervalSince1970</string>\n\t<key>Label</key>\n\t<string>pymobiledevice3</string>\n\t<key>Request</key>\n\t<string>GetValue</string>\n</dict>\n</plist>\n'
17:47:43 10 socket.sendall
17:47:43 10 data=b'\x00\x00\x01W<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Key</key>\n\t<string>TimeIntervalSince1970</string>\n\t<key>Label</key>\n\t<string>pymobiledevice3</string>\n\t<key>Request</key>\n\t<string>GetValue</string>\n</dict>\n</plist>\n'
17:47:43 10 Received chunk=b'\x00\x00\x01U'
17:47:43 10 len(chunk)=4
17:47:43 10 recvall data=b'\x00\x00\x01U'
17:47:43 10 size=4 len(data)=4
17:47:43 10 Received chunk=b'<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Key</key>\n\t<string>TimeIntervalSince1970</string>\n\t<key>Request</key>\n\t<string>GetValue</string>\n\t<key>Value</key>\n\t<real>1714859263.877667</real>\n</dict>\n</plist>\n'
17:47:43 10 len(chunk)=341
17:47:43 10 recvall data=b'<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Key</key>\n\t<string>TimeIntervalSince1970</string>\n\t<key>Request</key>\n\t<string>GetValue</string>\n\t<key>Value</key>\n\t<real>1714859263.877667</real>\n</dict>\n</plist>\n'
17:47:43 10 size=341 len(data)=341
```

---

### Windows only
lockdown.date 1min 43s after last transmit
pymob3 raises ConnectionAbortedError since len(chunk)==0
```
17:49:26 10 {'Label': 'pymobiledevice3', 'Request': 'GetValue', 'Key': 'TimeIntervalSince1970'}
17:49:26 10 plist_send=b'\x00\x00\x01W<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Key</key>\n\t<string>TimeIntervalSince1970</string>\n\t<key>Label</key>\n\t<string>pymobiledevice3</string>\n\t<key>Request</key>\n\t<string>GetValue</string>\n</dict>\n</plist>\n'
17:49:26 10 socket.sendall
17:49:26 10 data=b'\x00\x00\x01W<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Key</key>\n\t<string>TimeIntervalSince1970</string>\n\t<key>Label</key>\n\t<string>pymobiledevice3</string>\n\t<key>Request</key>\n\t<string>GetValue</string>\n</dict>\n</plist>\n'
17:49:26 10 Received chunk=b''
17:49:26 10 len(chunk)=0
Traceback (most recent call last):
  File "D:\repos\python\.venv\312_pymob3\Lib\site-packages\IPython\core\interactiveshell.py", line 3577, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-3-1d5b9629c9be>", line 1, in <module> 
    lds.date
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\lockdown.py", line 226, in date
    return datetime.datetime.fromtimestamp(self.get_value(key='TimeIntervalSince1970'))
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\lockdown.py", line 64, in _inner_reconnect_on_remote_close
    return f(*args, **kwargs)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\lockdown.py", line 447, in get_value
    res = self._request('GetValue', options)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\lockdown.py", line 554, in _request
    response = self.service.send_recv_plist(message)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\service_connection.py", line 131, in send_recv_plist
    return self.recv_plist(endianity=endianity)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\service_connection.py", line 180, in recv_plist
    return parse_plist(self.recv_prefixed(endianity=endianity))
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\service_connection.py", line 150, in recv_prefixed
    size = self.recvall(4)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\service_connection.py", line 141, in recvall
    raise ConnectionAbortedError()
ConnectionAbortedError

```

---

### Typical behaviour after radio silence
lockdown.date 4min 48s after previous request
I could not find exact timing on Windows when this occurs. Usually after 3-5 minutes.
```
17:54:14 10 {'Label': 'pymobiledevice3', 'Request': 'GetValue', 'Key': 'TimeIntervalSince1970'}
17:54:14 10 d={'Label': 'pymobiledevice3', 'Request': 'GetValue', 'Key': 'TimeIntervalSince1970'}
17:54:14 10 plist_send=b'\x00\x00\x01W<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Key</key>\n\t<string>TimeIntervalSince1970</string>\n\t<key>Label</key>\n\t<string>pymobiledevice3</string>\n\t<key>Request</key>\n\t<string>GetValue</string>\n</dict>\n</plist>\n'
17:54:14 10 socket.sendall
17:54:14 10 data=b'\x00\x00\x01W<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>Key</key>\n\t<string>TimeIntervalSince1970</string>\n\t<key>Label</key>\n\t<string>pymobiledevice3</string>\n\t<key>Request</key>\n\t<string>GetValue</string>\n</dict>\n</plist>\n'
Traceback (most recent call last):
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\service_connection.py", line 123, in sendall
    self.socket.sendall(data)
  File "C:\Python312\Lib\ssl.py", line 1211, in sendall
    v = self.send(byte_view[count:])
  File "C:\Python312\Lib\ssl.py", line 1180, in send
    return self._sslobj.write(data)
ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:2406)
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\lockdown.py", line 64, in _inner_reconnect_on_remote_close
    return f(*args, **kwargs)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\lockdown.py", line 447, in get_value
    res = self._request('GetValue', options)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\lockdown.py", line 554, in _request
    response = self.service.send_recv_plist(message)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\service_connection.py", line 130, in send_recv_plist
    self.send_plist(data, endianity=endianity, fmt=fmt)
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\service_connection.py", line 190, in send_plist
    return self.sendall(build_plist(d, endianity, fmt))
  File "D:\repos\python\StephenGemin\pymobiledevice3\pymobiledevice3\service_connection.py", line 125, in sendall
    raise ConnectionTerminatedError from e
pymobiledevice3.exceptions.ConnectionTerminatedError


# Re-establish socket connection and try again
```

